### PR TITLE
Chore: .gitignore에서 media, static 폴더 제외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ local_settings.py
 settings_local.py
 
 # Django media & static (선택)
-media/
 staticfiles/
 
 ############################
@@ -34,11 +33,6 @@ venv/
 env/
 ENV/
 pip-wheel-metadata/
-
-############################
-# Django collectstatic
-############################
-static/
 
 ############################
 # Docker


### PR DESCRIPTION
## 변경 사항 ##
git에서 media, static 폴더를 추적하게끔 .gitignore에서 제외했습니다.