### PR TITLE
Feat: 메인 페이지 연결 및 관리자 기능 확장

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.utils.translation import ngettext
+from django.contrib import messages
 
-from .models import User, Role, UserRoleLevel, TechStack
+from .models import User, Role, UserRoleLevel, TechStack, Report
 
 
 class UserRoleLevelInline(admin.TabularInline):
@@ -13,26 +15,76 @@ class UserRoleLevelInline(admin.TabularInline):
 
 @admin.register(User)
 class UserAdmin(BaseUserAdmin):
-    list_display = ["id", "username", "nickname", "email", "is_staff", "created_at"]
-    list_filter = ["is_staff", "is_active", "created_at"]
+    list_display = ["id", "username", "nickname", "email", "passion_level", "team_ban_count", "is_staff", "created_at"]
+    list_filter = ["is_staff", "is_active", "created_at", "passion_level"]
     search_fields = ["username", "nickname", "email"]
     ordering = ["-created_at"]
     inlines = [UserRoleLevelInline]
+    actions = ["clear_passion_level", "clear_team_ban", "ban_user"]
     
     fieldsets = BaseUserAdmin.fieldsets + (
         ("프로필 정보", {"fields": ("nickname", "profile_image", "bio", "tech_stacks")}),
+        ("관리 정보", {"fields": ("passion_level", "team_ban_count")}),
     )
+    
+    def clear_passion_level(self, request, queryset):
+        """열정 레벨 초기화"""
+        count = queryset.update(passion_level=None)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}명의 열정 레벨이 초기화되었습니다.",
+                f"{count}명의 열정 레벨이 초기화되었습니다.",
+                count,
+            ),
+        )
+    clear_passion_level.short_description = "🔄 선택된 사용자의 열정 레벨 초기화"
+    
+    def clear_team_ban(self, request, queryset):
+        """팀 밴 횟수 초기화"""
+        count = queryset.update(team_ban_count=0)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}명의 팀플 금지가 해제되었습니다.",
+                f"{count}명의 팀플 금지가 해제되었습니다.",
+                count,
+            ),
+        )
+    clear_team_ban.short_description = "🔓 선택된 사용자의 팀플 금지 해제"
+    
+    def ban_user(self, request, queryset):
+        """사용자에게 팀 밴 1회 추가"""
+        count = 0
+        for user in queryset:
+            user.team_ban_count += 1
+            user.save()
+            count += 1
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}명에게 팀플 금지 1회가 추가되었습니다.",
+                f"{count}명에게 팀플 금지 1회가 추가되었습니다.",
+                count,
+            ),
+        )
+    ban_user.short_description = "⛔ 선택된 사용자에게 팀 밴 1회 추가"
 
 
 @admin.register(TechStack)
 class TechStackAdmin(admin.ModelAdmin):
-    list_display = ["id", "name", "category", "created_at"]
+    list_display = ["id", "name", "category", "user_count", "created_at"]
     list_filter = ["category"]
     search_fields = ["name"]
     ordering = ["category", "name"]
     fieldsets = [
         ("기본 정보", {"fields": ["name", "category"]}),
     ]
+    
+    def user_count(self, obj):
+        """이 기술을 보유한 사용자 수"""
+        return obj.users.count()
+    user_count.short_description = "사용자 수"
 
 
 @admin.register(Role)
@@ -40,6 +92,48 @@ class RoleAdmin(admin.ModelAdmin):
     list_display = ["id", "code", "name", "created_at"]
     search_fields = ["code", "name"]
     ordering = ["code"]
+
+
+@admin.register(Report)
+class ReportAdmin(admin.ModelAdmin):
+    list_display = ["id", "reporter", "reported_user", "reason_preview", "status", "created_at"]
+    list_filter = ["status", "created_at"]
+    search_fields = ["reporter__nickname", "reported_user__nickname", "reason"]
+    ordering = ["-created_at"]
+    actions = ["approve_and_ban"]
+    readonly_fields = ["reporter", "reported_user", "reason", "created_at"]
+    
+    def reason_preview(self, obj):
+        """신고 사유 미리보기 (50자)"""
+        return obj.reason[:50] + "..." if len(obj.reason) > 50 else obj.reason
+    reason_preview.short_description = "신고 사유"
+    
+    def approve_and_ban(self, request, queryset):
+        """신고 승인 및 피신고자 밴"""
+        pending_reports = queryset.filter(status=Report.Status.PENDING)
+        count = 0
+        
+        for report in pending_reports:
+            # 피신고자에게 팀 밴 2회 추가
+            report.reported_user.team_ban_count += 2
+            report.reported_user.save()
+            
+            # 신고 상태 업데이트
+            report.status = Report.Status.APPROVED
+            report.admin_note = f"관리자 일괄 처리: {request.user.username}"
+            report.save()
+            count += 1
+        
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}명이 밴 처리되었습니다.",
+                f"{count}명이 밴 처리되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    approve_and_ban.short_description = "✅ 신고 승인 및 피신고자 밴"
 
 
 @admin.register(UserRoleLevel)

--- a/apps/projects/admin.py
+++ b/apps/projects/admin.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
+from django.contrib import messages
+from django.core.exceptions import ValidationError
+from django.utils.translation import ngettext
 
 from .models import Season, Project, ProjectApplication
+from .services import TeamMatchingService
 
 
 @admin.register(Season)
@@ -9,7 +13,7 @@ class SeasonAdmin(admin.ModelAdmin):
     list_filter = ["status", "is_active", "created_at"]
     search_fields = ["name"]
     ordering = ["-created_at"]
-    actions = ["activate_season", "deactivate_season"]
+    actions = ["activate_season", "deactivate_season", "run_team_matching"]
     
     def activate_season(self, request, queryset):
         """시즌 활성화 (이전 활성 시즌은 자동 비활성화)"""
@@ -24,6 +28,32 @@ class SeasonAdmin(admin.ModelAdmin):
         queryset.update(is_active=False)
         self.message_user(request, "시즌이 비활성화되었습니다.")
     
+    def run_team_matching(self, request, queryset):
+        """팀 매칭 알고리즘 실행"""
+        for season in queryset:
+            try:
+                result = TeamMatchingService.run_matching(season.id)
+                self.message_user(
+                    request,
+                    f"✅ [{season.name}] 팀 매칭 완료: "
+                    f"{result['teams_created']}팀 생성, "
+                    f"{result['total_matched']}명 매칭",
+                    messages.SUCCESS,
+                )
+            except ValidationError as e:
+                self.message_user(
+                    request,
+                    f"❌ [{season.name}] 팀 매칭 실패: {str(e)}",
+                    messages.ERROR,
+                )
+            except Exception as e:
+                self.message_user(
+                    request,
+                    f"❌ [{season.name}] 팀 매칭 오류: {str(e)}",
+                    messages.ERROR,
+                )
+    run_team_matching.short_description = "🤝 팀 매칭 알고리즘 실행"
+    
     activate_season.short_description = "✅ 선택된 시즌 활성화"
     deactivate_season.short_description = "❌ 선택된 시즌 비활성화"
 
@@ -34,6 +64,83 @@ class ProjectAdmin(admin.ModelAdmin):
     list_filter = ["status", "created_at"]
     search_fields = ["title", "description"]
     ordering = ["-created_at"]
+    actions = [
+        "change_status_to_open",
+        "change_status_to_matched",
+        "change_status_to_in_progress",
+        "change_status_to_completed",
+        "change_status_to_archived",
+    ]
+    
+    def change_status_to_open(self, request, queryset):
+        """상태 변경: 모집중"""
+        count = queryset.update(status=Project.Status.OPEN)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}개 프로젝트가 '모집중' 상태로 변경되었습니다.",
+                f"{count}개 프로젝트가 '모집중' 상태로 변경되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    change_status_to_open.short_description = "📢 상태 변경: 모집중"
+    
+    def change_status_to_matched(self, request, queryset):
+        """상태 변경: 매칭완료"""
+        count = queryset.update(status=Project.Status.MATCHED)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}개 프로젝트가 '매칭완료' 상태로 변경되었습니다.",
+                f"{count}개 프로젝트가 '매칭완료' 상태로 변경되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    change_status_to_matched.short_description = "✅ 상태 변경: 매칭완료"
+    
+    def change_status_to_in_progress(self, request, queryset):
+        """상태 변경: 진행중"""
+        count = queryset.update(status=Project.Status.IN_PROGRESS)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}개 프로젝트가 '진행중' 상태로 변경되었습니다.",
+                f"{count}개 프로젝트가 '진행중' 상태로 변경되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    change_status_to_in_progress.short_description = "⚙️ 상태 변경: 진행중"
+    
+    def change_status_to_completed(self, request, queryset):
+        """상태 변경: 완료"""
+        count = queryset.update(status=Project.Status.COMPLETED)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}개 프로젝트가 '완료' 상태로 변경되었습니다.",
+                f"{count}개 프로젝트가 '완료' 상태로 변경되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    change_status_to_completed.short_description = "🎉 상태 변경: 완료"
+    
+    def change_status_to_archived(self, request, queryset):
+        """상태 변경: 보관됨"""
+        count = queryset.update(status=Project.Status.ARCHIVED)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}개 프로젝트가 '보관됨' 상태로 변경되었습니다.",
+                f"{count}개 프로젝트가 '보관됨' 상태로 변경되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    change_status_to_archived.short_description = "📦 상태 변경: 보관됨"
 
 
 @admin.register(ProjectApplication)

--- a/apps/teams/admin.py
+++ b/apps/teams/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.contrib import messages
+from django.utils import timezone
+from django.utils.translation import ngettext
 
 from .models import Team, TeamMember
 
@@ -24,3 +27,40 @@ class TeamMemberAdmin(admin.ModelAdmin):
     list_filter = ["role", "is_active"]
     search_fields = ["user__nickname", "team__name"]
     ordering = ["-joined_at"]
+    actions = ["deactivate_members", "reactivate_members"]
+    
+    def deactivate_members(self, request, queryset):
+        """팀 멤버 비활성화 (탈퇴 처리)"""
+        now = timezone.now()
+        count = 0
+        
+        for member in queryset.filter(is_active=True):
+            member.is_active = False
+            member.left_at = now
+            member.save()
+            count += 1
+        
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}명이 팀에서 제거되었습니다.",
+                f"{count}명이 팀에서 제거되었습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    deactivate_members.short_description = "🚪 선택된 멤버 비활성화 (탈퇴)"
+    
+    def reactivate_members(self, request, queryset):
+        """팀 멤버 재활성화"""
+        count = queryset.filter(is_active=False).update(is_active=True, left_at=None)
+        self.message_user(
+            request,
+            ngettext(
+                f"{count}명이 팀에 재입장했습니다.",
+                f"{count}명이 팀에 재입장했습니다.",
+                count,
+            ),
+            messages.SUCCESS,
+        )
+    reactivate_members.short_description = "🔄 선택된 멤버 재활성화"

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,8 +8,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, Sp
 
 urlpatterns = [
     
-    path("", initial_view, name="initial"),  # 초기 화면 (initial.html)
-    path("main/", main_view, name="main"),  # 메인 화면 (main.html)
+    path("", main_view, name="main"),  # 메인 화면 (main.html)
     path("admin/", admin.site.urls),
     
     #   allauth (로그인/소셜로그인)

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,7 +3,7 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from django.views.generic import RedirectView
-from .views import initial_view, main_view
+from .views import main_view
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [

--- a/config/views.py
+++ b/config/views.py
@@ -1,15 +1,5 @@
 from django.shortcuts import render
 
-
-# 초기 화면 (initial.html)
-def initial_view(request):
-    """
-    초기 화면 (initial.html)
-    - 랜딩 페이지
-    """
-    return render(request, "initial.html")
-
-
 # 메인 화면 (main.html)
 def main_view(request):
     """

--- a/config/views.py
+++ b/config/views.py
@@ -1,10 +1,60 @@
 from django.shortcuts import render
+from datetime import date
+
+from apps.accounts.models import UserRoleLevel
+from apps.projects.models import Project, Season
+from apps.reflections.models import Retrospective
 
 # 메인 화면 (main.html)
 def main_view(request):
     """
     메인 화면 (main.html)
-    - 비로그인: 컨텐츠들 제목 섹션 - 로그인 후 이용해보세요.
-    - 로그인: 각 섹션 클릭 시 해당하는 html로 이동
+    - 비로그인: request.user가 AnonymousUser이므로 템플릿에서 자동 분기
+    - 로그인: 
+      1. 오늘의 작업 기록 (회고)
+      2. 팀 매칭 모집 (현재 시즌 프로젝트들)
+      3. KITUP 프로젝트 (보관된 프로젝트들)
     """
-    return render(request, "main.html")
+    
+    user = request.user
+    context = {}
+    
+    # 로그인 상태만 추가 데이터 조회
+    if user.is_authenticated:
+        """회고 부분"""
+        
+        """팀 매칭 부분"""
+        season = Season.get_active_season()
+        is_matching_period = season and season.is_matching_period() if season else False
+        
+        # 유저의 역할별 레벨
+        role_levels = (
+            UserRoleLevel.objects
+            .filter(user=user)
+            .select_related("role")
+        )
+        
+        role_level_map = {
+            rl.role.code: rl.level
+            for rl in role_levels
+        }
+        
+        # 현재 시즌의 모집 중인 프로젝트들
+        matching_projects = None
+        if season and is_matching_period:
+            matching_projects = Project.objects.filter(
+                status__in=[Project.Status.OPEN, Project.Status.MATCHED]
+            ).select_related('team').order_by('-created_at')[:6]
+        
+        context["is_matching_period"] = is_matching_period
+        context["role_levels"] = role_level_map
+        context["matching_projects"] = matching_projects
+    
+    """KITUP 프로젝트 부분"""
+    archived_projects = Project.objects.filter(
+        status=Project.Status.ARCHIVED
+    ).select_related('team').order_by('-created_at')
+    
+    context["archived_projects"] = archived_projects
+    
+    return render(request, "main.html", context)


### PR DESCRIPTION
## 🔥 작업 내용
### 1) 라우팅/초기 진입 개선
- 초기 화면(`/`)을 메인 화면(`main.html`)로 연결하도록 라우팅 수정
- `initial_view` import 제거 및 URL 정리 (`config/urls.py`)

### 2) 메인 페이지 로직 구현 (`config/views.py`)
- `main_view`에서 메인 화면 데이터 구성 로직 추가
  - 로그인 상태에서만 추가 데이터 조회하도록 분기
  - 현재 활성 시즌 조회 및 매칭 기간 여부 계산
  - 유저 역할별 레벨(UserRoleLevel) 조회 후 `role_level_map` 구성
  - 매칭 기간일 때 모집/매칭 프로젝트 일부 노출(OPEN/MATCHED)
  - KITUP 보관 프로젝트(ARCHIVED) 목록 조회

### 3) 관리자 페이지 기능 구현/개선
- Accounts Admin (`apps/accounts/admin.py`)
  - UserAdmin list_display/list_filter 확장 (passion_level, team_ban_count 등)
  - 관리자 액션 추가
    - 열정 레벨 초기화
    - 팀플 금지 해제
    - 팀 밴 1회 추가
  - TechStackAdmin에 `user_count` 표시 추가
  - ReportAdmin 추가
    - 신고 목록/검색/필터/정렬 제공
    - `approve_and_ban`: PENDING 신고 승인 + 피신고자 팀 밴 2회 추가 + admin_note 기록

- Projects Admin (`apps/projects/admin.py`)
  - SeasonAdmin에 팀 매칭 실행 액션 추가 (`run_team_matching`)
    - 성공/실패 메시지 처리
  - ProjectAdmin에 상태 일괄 변경 액션 구성
    - OPEN / MATCHED / IN_PROGRESS / COMPLETED / ARCHIVED

- Teams Admin (`apps/teams/admin.py`)
  - TeamMemberAdmin 액션 추가
    - 선택 멤버 비활성화(탈퇴 처리: is_active=False, left_at 기록)
    - 비활성 멤버 재활성화(left_at 초기화)


## 🔗 연관 이슈
- resolves #56 


## ⚠️ 참고 사항
- 메인 페이지 데이터는 `request.user.is_authenticated`일 때만 추가 조회되도록 구성했습니다.
- 시즌 매칭 프로젝트는 매칭 기간일 때만 노출되며, 상태는 `OPEN/MATCHED`를 대상으로 합니다.
- 신고 승인 액션은 `PENDING` 상태만 처리하며, 처리 시 피신고자 `team_ban_count += 2` 적용됩니다.
- main 페이지에서 회고 기능은 아직 구현되지 않았습니다.
- 개발한 관리자 기능을 정리하면 다음과 같습니다. 더 필요한 기능이 있으면 말해주세요.
  - passion_level 초기화 기능
  - 팀 밴 부여/해제 기능
  - 신고 승인  기능 
  - 팀 매칭 알고리즘 실행 기능
  - 프로젝트 상태 변경 기능
  - 기술 스택 사용자 수 표시 기능