### PR TITLE
docs: 누락된 requirements.txt 모듈 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.11.0
 attrs==25.4.0
+bleach==6.3.0
 certifi==2026.1.4
 cffi==2.0.0
 charset-normalizer==3.4.4
@@ -12,6 +13,7 @@ idna==3.11
 inflection==0.5.1
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
+Markdown==3.10.1
 pillow==12.1.0
 psycopg2-binary==2.9.10
 pycparser==3.0
@@ -27,3 +29,4 @@ typing_extensions==4.15.0
 tzdata==2025.3
 uritemplate==4.2.0
 urllib3==2.6.3
+webencodings==0.5.1


### PR DESCRIPTION
## 🔥 작업 내용
<!-- 이 PR에서 무엇을 했는지 요약 -->
requirement.txt에 누락된 `markdown`, `bleach` 모듈 추가

## ⚠️ 참고 사항
<!-- 리뷰 시 유의할 점 / 고민했던 부분 -->
module not found 뜨면 꼭 pip install -r requirements.txt 합시다
또 새 모듈 추가했으면 pip freeze > requirements.txt 하고