### PR TITLE
Fix: role 데이터 오류 수정 및 프로필 수정에서 닉네임 검증 구현

### DIFF
--- a/apps/accounts/api_urls.py
+++ b/apps/accounts/api_urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path("check-username/", views.check_username, name="check_username"),
     path("check-email/", views.check_email, name="check_email"),
+    path("check-nickname/", views.check_nickname, name="check_nickname"),
 ]

--- a/apps/accounts/fixtures/roles.json
+++ b/apps/accounts/fixtures/roles.json
@@ -1,0 +1,35 @@
+[
+  {
+    "model": "accounts.Role",
+    "pk": 1,
+    "fields": {
+      "name": "PM(기획)",
+      "code": "PM",
+      "description": "프로젝트 기획 및 관리",
+      "created_at": "2026-02-06T00:00:00Z",
+      "updated_at": "2026-02-06T00:00:00Z"
+    }
+  },
+  {
+    "model": "accounts.Role",
+    "pk": 2,
+    "fields": {
+      "name": "프론트엔드",
+      "code": "FRONTEND",
+      "description": "프론트엔드 개발",
+      "created_at": "2026-02-06T00:00:00Z",
+      "updated_at": "2026-02-06T00:00:00Z"
+    }
+  },
+  {
+    "model": "accounts.Role",
+    "pk": 3,
+    "fields": {
+      "name": "백엔드",
+      "code": "BACKEND",
+      "description": "백엔드 개발",
+      "created_at": "2026-02-06T00:00:00Z",
+      "updated_at": "2026-02-06T00:00:00Z"
+    }
+  }
+]

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+import re
 from .models import User, TechStack
 
 
@@ -38,8 +39,21 @@ class OnboardingForm(forms.ModelForm):
         nick = (self.cleaned_data.get("nickname") or "").strip()
         if not nick:
             raise forms.ValidationError("닉네임은 필수입니다.")
+        
+        # 길이 검증
+        if len(nick) < 2:
+            raise forms.ValidationError("닉네임은 최소 2자 이상이어야 합니다.")
+        if len(nick) > 20:
+            raise forms.ValidationError("닉네임은 최대 20자 이하여야 합니다.")
+        
+        # 특수문자 검증 (한글, 영문, 숫자, 밑줄, 하이픈만 허용)
+        if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', nick):
+            raise forms.ValidationError("닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다.")
+        
+        # 중복 확인
         if User.objects.filter(nickname=nick).exclude(pk=self.instance.pk).exists():
             raise forms.ValidationError("이미 사용 중인 닉네임입니다.")
+        
         return nick
 
     def clean_github_id(self):
@@ -96,8 +110,21 @@ class ProfileUpdateForm(forms.ModelForm):
         nick = (self.cleaned_data.get("nickname") or "").strip()
         if not nick:
             raise forms.ValidationError("닉네임은 필수입니다.")
+        
+        # 길이 검증
+        if len(nick) < 2:
+            raise forms.ValidationError("닉네임은 최소 2자 이상이어야 합니다.")
+        if len(nick) > 20:
+            raise forms.ValidationError("닉네임은 최대 20자 이하여야 합니다.")
+        
+        # 특수문자 검증 (한글, 영문, 숫자, 밑줄, 하이픈만 허용)
+        if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', nick):
+            raise forms.ValidationError("닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다.")
+        
+        # 중복 확인
         if User.objects.filter(nickname=nick).exclude(pk=self.instance.pk).exists():
             raise forms.ValidationError("이미 사용 중인 닉네임입니다.")
+        
         return nick
 
     def clean_github_id(self):

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -42,6 +42,38 @@ def check_email(request):
     return JsonResponse({"available": True, "message": "사용 가능한 이메일입니다."})
 
 
+@require_GET
+def check_nickname(request):
+    """닉네임 중복 확인 API"""
+    nickname = request.GET.get("nickname", "").strip()
+    current_user_id = request.GET.get("user_id")  # 프로필 수정 시 자신의 닉네임 제외
+    
+    if not nickname:
+        return JsonResponse({"available": False, "message": "닉네임을 입력해주세요."})
+    
+    # 길이 검증 (2-20자)
+    if len(nickname) < 2:
+        return JsonResponse({"available": False, "message": "닉네임은 최소 2자 이상이어야 합니다."})
+    
+    if len(nickname) > 20:
+        return JsonResponse({"available": False, "message": "닉네임은 최대 20자 이하여야 합니다."})
+    
+    # 특수문자 검증 (한글, 영문, 숫자, 밑줄, 하이픈만 허용)
+    import re
+    if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', nickname):
+        return JsonResponse({"available": False, "message": "닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다."})
+    
+    # 중복 확인 (현재 사용자는 제외)
+    query = User.objects.filter(nickname=nickname)
+    if current_user_id:
+        query = query.exclude(pk=current_user_id)
+    
+    if query.exists():
+        return JsonResponse({"available": False, "message": "이미 사용 중인 닉네임입니다."})
+    
+    return JsonResponse({"available": True, "message": "사용 가능한 닉네임입니다."})
+
+
 @login_required
 def level_test(request):
     """

--- a/apps/guides/management/commands/load_guides.py
+++ b/apps/guides/management/commands/load_guides.py
@@ -21,8 +21,13 @@ class Command(BaseCommand):
             GuideTask.objects.all().delete()
             self.stdout.write(self.style.WARNING('기존 가이드 데이터를 삭제했습니다'))
 
-        # fixture 로드
+        # fixture 로드 (순서 중요: roles -> guides)
         try:
+            # 1. roles 먼저 로드 (FK 의존성)
+            call_command('loaddata', 'roles')
+            self.stdout.write(self.style.SUCCESS('✅ Roles 데이터 로드됨'))
+            
+            # 2. guides 로드
             call_command('loaddata', 'guides')
             self.stdout.write(
                 self.style.SUCCESS('✅ 가이드 데이터를 성공적으로 로드했습니다!')

--- a/static/css/profile_edit.css
+++ b/static/css/profile_edit.css
@@ -166,6 +166,65 @@
     color: #9ca3af;
 }
 
+/* 닉네임 검증 스타일 */
+.nickname-check-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+}
+
+.nickname-check-wrapper input {
+    flex: 1;
+}
+
+.check-btn {
+    padding: 10px 20px;
+    background-color: #4B7EFF;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    white-space: nowrap;
+}
+
+.check-btn:hover {
+    background-color: #3563D9;
+}
+
+.check-btn:active {
+    background-color: #2548B8;
+}
+
+.check-status {
+    font-size: 12px;
+    font-weight: 500;
+    margin-left: 10px;
+    white-space: nowrap;
+}
+
+.check-status.success {
+    color: #10B981;
+}
+
+.check-status.error {
+    color: #EF4444;
+}
+
+/* 입력 필드 유효성 표시 */
+.input-field.valid {
+    border: 2px solid #10B981;
+    background-color: #F0FDF4;
+}
+
+.input-field.invalid {
+    border: 2px solid #EF4444;
+    background-color: #FEF2F2;
+}
+
 /* 파일 입력 숨기기 */
 input[type="file"] {
     display: none;

--- a/templates/account/profile_edit.html
+++ b/templates/account/profile_edit.html
@@ -28,7 +28,11 @@
                 <div class="info-table">
                     <div class="info-row">
                         <label class="label">닉네임</label>
-                        {{ form.nickname }}
+                        <div class="nickname-check-wrapper">
+                            {{ form.nickname }}
+                            <button type="button" class="check-btn" id="check-nickname-btn">중복확인</button>
+                            <span class="check-status" id="check-status"></span>
+                        </div>
                     </div>
                     <div class="info-row">
                         <label class="label">아이디</label>
@@ -80,6 +84,67 @@ document.addEventListener('DOMContentLoaded', function() {
     const profileInput = document.getElementById('id_profile_image');
     const previewImage = document.getElementById('preview-image');
     const defaultImageUrl = "{% static 'images/default_profile.png' %}";
+    const nicknameInput = document.getElementById('id_nickname');
+    const checkNicknameBtn = document.getElementById('check-nickname-btn');
+    const checkStatus = document.getElementById('check-status');
+    
+    // 닉네임 검증
+    if (checkNicknameBtn && nicknameInput) {
+        // 중복확인 버튼 클릭
+        checkNicknameBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            checkNicknameDuplicate();
+        });
+        
+        // 닉네임 입력 중 실시간 검증
+        nicknameInput.addEventListener('input', function() {
+            checkStatus.textContent = '';
+            checkStatus.className = 'check-status';
+            nicknameInput.classList.remove('valid', 'invalid');
+        });
+        
+        // Enter 키로도 검증
+        nicknameInput.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                checkNicknameDuplicate();
+            }
+        });
+    }
+    
+    function checkNicknameDuplicate() {
+        const nickname = nicknameInput.value.trim();
+        const userId = "{{ user.id }}";
+        
+        if (!nickname) {
+            checkStatus.textContent = '닉네임을 입력하세요.';
+            checkStatus.className = 'check-status error';
+            nicknameInput.classList.add('invalid');
+            return;
+        }
+        
+        // API 호출
+        fetch(`/api/accounts/check-nickname/?nickname=${encodeURIComponent(nickname)}&user_id=${userId}`)
+            .then(response => response.json())
+            .then(data => {
+                if (data.available) {
+                    checkStatus.textContent = '✓ ' + data.message;
+                    checkStatus.className = 'check-status success';
+                    nicknameInput.classList.add('valid');
+                    nicknameInput.classList.remove('invalid');
+                } else {
+                    checkStatus.textContent = '✗ ' + data.message;
+                    checkStatus.className = 'check-status error';
+                    nicknameInput.classList.add('invalid');
+                    nicknameInput.classList.remove('valid');
+                }
+            })
+            .catch(error => {
+                console.error('오류:', error);
+                checkStatus.textContent = '검증 중 오류가 발생했습니다.';
+                checkStatus.className = 'check-status error';
+            });
+    }
     
     if (profileInput) {
         // input 필드 숨기기


### PR DESCRIPTION
## 🔥 작업 내용
### 1) guides fixture 로딩 FK 오류 해결
- `accounts/fixtures/roles.json` 추가
- `load_guides` 커맨드에서 roles → guides 순으로 loaddata 수행하도록 수정
  - GuideCard.role FK 의존성으로 인해 roles 선 로드 필요

### 2) 프로필 수정 화면 닉네임 검증/중복확인 추가
- Form 레벨 닉네임 검증 추가(길이/허용문자/중복)
- 닉네임 중복확인 API 추가
  - `GET /api/accounts/check-nickname/?nickname=...&user_id=...`
- 프로필 수정 화면에 “중복확인” 버튼 + 상태 표시 UI 추가
- 관련 CSS/JS 추가

## 🔗 연관 이슈
- resolves #92 

## ⚠️ 참고 사항
- fixture 로드 시 `python manage.py load_guides` 실행(roles 선로딩 포함)
- 닉네임 검증 규칙: 2~20자, 한글/영문/숫자/_(언더스코어)/-(하이픈)만 허용
