### PR TITLE
Feat: 팀 매칭 취소 기능 추가

### DIFF
--- a/apps/teams/urls.py
+++ b/apps/teams/urls.py
@@ -13,6 +13,12 @@ urlpatterns = [
     # 열정 테스트 (팀플 신청 시)
     path("passion-test/", views.passion_test, name="passion_test"),  # passion_test.html
     
+    # 열정 테스트 결과 제출
+    path("passion-submit/", views.passion_submit, name="passion_submit"),
+    
+    # 팀 매칭 신청 취소
+    path("cancel/", views.team_matching_cancel, name="team_matching_cancel"),
+    
     # 팀 매칭 결과/대기 화면
     path("status/", views.team_status, name="team_status"),  # team.html
 ]

--- a/apps/teams/views.py
+++ b/apps/teams/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render, redirect
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 
 from rest_framework import viewsets
 from django.utils import timezone
@@ -110,6 +111,34 @@ def passion_submit(request):
     request.user.save(update_fields=["passion_level"])
     
     return redirect("teams:team_status")
+
+
+@login_required
+def team_matching_cancel(request):
+    """
+    팀 매칭 신청 취소
+    
+    - 팀 매칭 기간 중에만 취소 가능
+    - 프로젝트 기간이면 취소 불가능
+    - 사용자의 TeamMember 레코드 삭제
+    - passion_level을 NULL로 초기화 (다시 열정 테스트 강제)
+    """
+    if request.method != "POST":
+        return HttpResponseBadRequest("잘못된 요청입니다.")
+    
+    season = Season.get_active_season()
+    
+    # 팀 매칭 기간이 아니면 취소 불가능
+    if not season or not season.is_matching_period():
+        messages.error(request, "❌ 팀 매칭 기간이 아닙니다. 취소할 수 없습니다.")
+        return redirect("teams:team_status")
+    
+    # 열정 레벨 초기화
+    request.user.passion_level = None
+    request.user.save(update_fields=["passion_level"])
+    
+    messages.success(request, "✅ 팀 매칭 신청이 취소되었습니다.")
+    return redirect("teams:team_apply")
 
 
 @login_required


### PR DESCRIPTION
## 🔥 작업 내용
<!-- 이 PR에서 무엇을 했는지 요약 -->
팀 매칭 신청을 한 뒤 취소하는 기능을 구현하였습니다.

## 🔗 연관 이슈
<!-- closes / resolves / fixes 중 하나 사용 -->
- resolves #106 

## ⚠️ 참고 사항
<!-- 리뷰 시 유의할 점 / 고민했던 부분 -->
팀 매칭을 취소하면 기존에 했던 열정 레벨이 초기화 되고 재신청시 열정 레벨 테스트를 다시 진행해야합니다.