### PR TITLE
feat: 신고 작성 API 구현 및 AJAX로 적용

### DIFF
--- a/apps/accounts/api_urls.py
+++ b/apps/accounts/api_urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path("check-email/", views.check_email, name="check_email"),
     path("check-nickname/", views.check_nickname, name="check_nickname"),
     path("level-test/submit/", views.level_submit, name="level_submit"),
+    path("report/create", views.create_report, name="create_report"),
 ]

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+class ReportCreateRequestSerializer(serializers.Serializer):
+    reported_user_id = serializers.IntegerField()
+    reason = serializers.CharField(min_length=1, max_length=2000)
+
+class ReportCreateResponseSerializer(serializers.Serializer):
+    ok = serializers.BooleanField()
+    report_id = serializers.IntegerField()

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -8,8 +8,15 @@ from django.contrib import messages
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.views.decorators.http import require_GET, require_POST
 
+from drf_spectacular.utils import extend_schema
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+
 from .forms import OnboardingForm, ProfileUpdateForm
-from .models import Role, User, UserRoleLevel
+from .models import Role, User, UserRoleLevel, Report
+from .serializers import ReportCreateRequestSerializer, ReportCreateResponseSerializer
 
 
 @require_GET
@@ -240,3 +247,45 @@ def withdraw(request):
         return redirect("/")
 
     return render(request, "account/withdraw.html")
+
+@extend_schema(
+    tags=["Accounts"],
+    summary="유저 신고 생성",
+    request=ReportCreateRequestSerializer,
+    responses={201: ReportCreateResponseSerializer, 400: None, 409: None},
+)
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def create_report(request):
+    ser = ReportCreateRequestSerializer(data=request.data)
+    ser.is_valid(raise_exception=True)
+
+    reported_user_id = ser.validated_data["reported_user_id"]
+    reason = ser.validated_data["reason"]
+
+    if not reported_user_id:
+        return JsonResponse({"ok": False, "error": "reported_user_id is required"}, status=400)
+    if not reason:
+        return JsonResponse({"ok": False, "error": "reason is required"}, status=400)
+
+    reported_user = get_object_or_404(User, pk=reported_user_id)
+
+    # 자기 자신 신고 방지
+    if reported_user.id == request.user.id:
+        return JsonResponse({"ok": False, "error": "cannot report yourself"}, status=400)
+
+    # (선택) 동일 대상 중복 신고 방지: 대기중(PENDING) 하나만 허용 같은 정책
+    if Report.objects.filter(
+        reporter=request.user,
+        reported_user=reported_user,
+        status=Report.Status.PENDING,
+    ).exists():
+        return JsonResponse({"ok": False, "error": "already reported (pending)"}, status=409)
+
+    report = Report.objects.create(
+        reporter=request.user,
+        reported_user=reported_user,
+        reason=reason,
+    )
+
+    return JsonResponse({"ok": True, "report_id": report.id}, status=201)

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -2,6 +2,15 @@ document.addEventListener('DOMContentLoaded', function() {
     const modal = document.getElementById('reportModal');
     const openBtn = document.querySelector('.btn_report'); 
     const closeBtns = document.querySelectorAll('.close-btn');
+    const form = document.getElementById("reportForm");
+    const textarea = form.querySelector("textarea[name='reason']");
+
+
+    /* CSRF */
+    function getCookie(name) {
+        const v = document.cookie.match("(^|;)\\s*" + name + "\\s*=\\s*([^;]+)");
+        return v ? v.pop() : "";
+    }
 
     // 팝업 열기
     if(openBtn) {
@@ -15,6 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
     closeBtns.forEach(btn => {
         btn.addEventListener('click', () => {
             modal.style.display = 'none';
+            form.reset();
         });
     });
 
@@ -22,6 +32,52 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('click', (e) => {
         if (e.target === modal) {
             modal.style.display = 'none';
+        }
+    });
+
+    form.addEventListener("submit", async (e) => {
+        e.preventDefault();
+
+        const selected = form.querySelector(
+            "input[name='reported_user']:checked"
+        );
+        const reason = textarea.value.trim();
+
+        if (!selected) {
+            alert("신고할 팀원을 선택해주세요.");
+            return;
+        }
+        if (!reason) {
+            alert("신고 사유를 입력해주세요.");
+            return;
+        }
+
+        try {
+            const res = await fetch("/api/accounts/report/create", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
+                credentials: "same-origin",
+                body: JSON.stringify({
+                    reported_user_id: selected.value,
+                    reason: reason,
+                }),
+            });
+
+            const data = await res.json();
+
+            if (!res.ok) {
+                alert(data.error || "신고에 실패했습니다.");
+                return;
+            }
+
+            alert("신고가 접수되었습니다.");
+            modal.style.display = "none";
+            form.reset();
+        } catch (err) {
+            alert("네트워크 오류가 발생했습니다.");
         }
     });
 });

--- a/templates/projects/dashboard.html
+++ b/templates/projects/dashboard.html
@@ -161,6 +161,7 @@
         </div>
         
         <form id="reportForm">
+            {% csrf_token %}
             <div class="modal-body">
                 <p class="modal-desc">신고하실 팀원을 선택하고 사유를 입력해주세요.</p>
                 


### PR DESCRIPTION
## 🔥 작업 내용
<!-- 이 PR에서 무엇을 했는지 요약 -->
- 신고 기능 구현
  - 신고 작성 API 구현 (api/accounts/report/create)
  - 대시보드에서 API를 AJAX로 호출하여 신고 기능 구현

## 🔗 연관 이슈
<!-- closes / resolves / fixes 중 하나 사용 -->
- resolves #105 

## ⚠️ 참고 사항
<!-- 리뷰 시 유의할 점 / 고민했던 부분 -->
- 현재 신고의 운영진 처리는 admin으로만 가능함
- 신고를 처리해도, 실질적인 패널티를 부과하지는 않음