### PR TITLE
chore: 배포 서버에서 https로 rediret_uri 만들 수 있도록 settings.py 수정

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -26,6 +26,17 @@ CSRF_TRUSTED_ORIGINS = [
     'https://kitup.duckdns.org',
 ]
 
+if os.getenv("ENV", "dev") == "prod":
+    DEBUG = False
+
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    USE_X_FORWARDED_HOST = True
+    ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
+
+    CSRF_TRUSTED_ORIGINS = [
+        "https://kitup.duckdns.org",
+    ]
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
## 🔥 작업 내용
<!-- 이 PR에서 무엇을 했는지 요약 -->
소셜 로그인에 주소를 추가해도 안 되는 이슈가 있습니다. 배포 서버 주소가 https로 되어 있는 것에 반해 요청 주소는 http로 되어 있는 문제가 있습니다. 
배포 서버에서는 이거 해결하는 코드 + DEBUG = False로 적용됩니다. 

## ⚠️ 참고 사항
<!-- 리뷰 시 유의할 점 / 고민했던 부분 -->
.env 파일에 
```
ENV=prod
```
를 추가하면 배포 설정이 적용됩니다.