### PR TITLE
note_list 반응형 적용, 회고 질문 기본값을 간소화 버전으로 수정

### DIFF
--- a/apps/reflections/guide_templates/retrospective_compact.json
+++ b/apps/reflections/guide_templates/retrospective_compact.json
@@ -1,0 +1,10 @@
+{
+  "key": "compact",
+  "title": "오늘의 회고",
+  "intro": [],
+  "questions": [
+    { "id": "q1_study", "order": 1, "title": "오늘 무엇을 공부했나요?" },
+    { "id": "q2_hard", "order": 2, "title": "어려웠던 지점은 무엇이었고, 어떻게 해결하거나 해결하지 못했나요?" },
+    { "id": "q3_tomorrow", "order": 3, "title": "내일은 무엇을 할 것인가요?" }
+  ]
+}

--- a/apps/reflections/serializers.py
+++ b/apps/reflections/serializers.py
@@ -65,7 +65,7 @@ class RetrospectiveWriteSerializer(serializers.ModelSerializer):
         return build_markdown(guide, answers_json, title=title)
 
     def create(self, validated_data):
-        template_key = validated_data.get("template_key") or "default"
+        template_key = validated_data.get("template_key") or "compact"
         answers_json = validated_data.get("answers_json") or {}
         title = validated_data.get("title")
 
@@ -76,7 +76,7 @@ class RetrospectiveWriteSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         # 기존 값과 병합해서 md 재생성
-        template_key = validated_data.get("template_key", instance.template_key or "default")
+        template_key = validated_data.get("template_key", instance.template_key or "compact")
         answers_json = validated_data.get("answers_json", instance.answers_json or {})
         title = validated_data.get("title", instance.title)
 

--- a/apps/reflections/views.py
+++ b/apps/reflections/views.py
@@ -151,7 +151,7 @@ def note_create(request):
       :tpl: 선택할 질문 템플릿 (현재는 default 하나만)
       
     """
-    tpl_key = request.GET.get("tpl") or "default"
+    tpl_key = request.GET.get("tpl") or "compact"
     guide = load_guide(tpl_key)
 
     # ✅ draft_key 발급/유지
@@ -240,7 +240,7 @@ def note_update(request, note_id):
     """회고 수정 - note_create와 동일하게 guide 기반으로 렌더/저장"""
     note = get_object_or_404(Retrospective, id=note_id, user=request.user)
 
-    tpl = note.template_key or "default"
+    tpl = note.template_key or "compact"
     guide = load_guide(tpl)
 
     # 기존 답변(answers_json)로 textarea 기본값 채우기

--- a/static/css/reflections.css
+++ b/static/css/reflections.css
@@ -119,6 +119,7 @@ button {
   position: relative;
   display: inline-flex;
   align-items: center;
+  min-width: 0;
 }
 
 .ref-selectbox {
@@ -130,7 +131,8 @@ button {
   font-size: 14px;
   font-weight: 600;
   color: var(--gray-900);
-  min-width: 180px;
+  min-width: 0px;
+  width: 100%;
 }
 
 .ref-selectchev {
@@ -664,16 +666,27 @@ button {
 }
 
 .ref-q-num {
+  flex: 0 0 22px;
   width: 22px;
   height: 22px;
+  min-width: 22px;
+  min-height: 22px;
+  aspect-ratio: 1 / 1;
+
+  /* 원 스타일 */
   border-radius: 50%;
-  background: #2f2f2f;
-  color: #fff;
+  background: #2f2f2f;   /* 검은 원 */
+  color: #ffffff;        /* 흰 숫자 */
+
+  /* 가운데 정렬 */
   display: inline-flex;
   align-items: center;
   justify-content: center;
+
+  /* 숫자 안정화 */
   font-size: 12px;
   font-weight: 900;
+  line-height: 1;
 }
 
 .ref-q-actions {

--- a/static/css/reflections.css
+++ b/static/css/reflections.css
@@ -40,7 +40,7 @@ button {
   cursor: pointer;
 }
 /* =========================
-   Page
+   Note List Page
 ========================= */
 .ref-page {
   background: var(--blue-0);
@@ -412,9 +412,9 @@ button {
     padding: 10px 14px;
   }
 
-  .ref-selectbox {
+  /* .ref-selectbox {
     min-width: 140px;
-  }
+  } */
 
   .note-title {
     font-size: 18px;
@@ -424,6 +424,95 @@ button {
     font-size: 15px;
   }
 }
+
+/* =========================
+   Mobile Responsive
+========================= */
+@media (max-width: 640px) {
+
+  .note-card {
+    flex-direction: column;
+    gap: 12px;
+    padding: 18px;
+  }
+
+  /* 상단 액션 고정 */
+  .bookmark-btn {
+    position: absolute;
+    top: 14px;
+    left: 14px;
+  }
+
+  .note-morewrap {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+
+  /* 본문 영역 여백 확보 */
+  .note-main {
+    padding-top: 32px;
+  }
+
+  /* 제목 / 태그 세로 정렬 */
+  .note-topline {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .note-title {
+    font-size: 17px;
+    white-space: normal;
+    line-height: 1.3;
+  }
+
+  .note-tag {
+    font-size: 11px;
+    padding: 5px 10px;
+  }
+
+  .note-preview {
+    font-size: 14px;
+    line-clamp: 3;
+    -webkit-line-clamp: 3;
+  }
+
+  .note-date {
+    font-size: 13px;
+  }
+
+  .ref-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 12px;
+  }
+
+  /* ===== 위 줄: 정렬 / 역할 ===== */
+  .ref-select-container {
+    flex: 0 0 calc(50% - 6px);
+    min-width: 0;
+  }
+
+  .ref-selectbox {
+    width: 100%;
+    min-width: 0;          /* ← 핵심 */
+    padding-right: 44px;   /* 화살표 공간 */
+  }
+
+  .ref-selectchev {
+    right: 14px;
+  }
+
+  /* ===== 아래 줄: 북마크 / 글쓰기 ===== */
+  .bookmark-filter-btn,
+  .ref-writebtn {
+    flex: 0 0 calc(50% - 6px);
+    justify-content: center;
+    text-align: center;
+  }
+}
+
 
 /* =========================
    Note Form (create/update)


### PR DESCRIPTION
## 🔥 작업 내용
<!-- 이 PR에서 무엇을 했는지 요약 -->
- note_list에 반응형 적용
- 회고 질문 기본값을 간소화 버전으로 적용 (reflection_compact.json)
  - 이전에 작성한 회고와 호환되기 위한 구조

## ⚠️ 참고 사항
<!-- 리뷰 시 유의할 점 / 고민했던 부분 -->
기본값을 적용하는 방식을 썼는데, 프론트단에서 질문 가이드를 선택하지는 못하므로, 지금부터 새로 생성하는 모든 회고는 compact 구조를 따르게 됩니다. 

확장성 있는 구조로 미리 짜두길 잘했네요...