### PR TITLE
Feat: 대시보드 마크다운 렌더링 및 전체 가이드 진척도 구현

### DIFF
--- a/apps/guides/views.py
+++ b/apps/guides/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required
 
 from apps.projects.models import Project
 from apps.teams.models import TeamMember
+from apps.accounts.models import Role
 from .models import GuideCard, GuideTaskProgress, ProjectProgress
 
 
@@ -64,10 +65,50 @@ def mission(request):
             'is_completed': is_card_completed,
         })
     
-    # 모든 역할의 진척도
-    all_role_progress = ProjectProgress.objects.filter(
-        project=project
-    ).select_related('role')
+    # 모든 역할의 진척도 계산
+    all_role_progress = []
+    
+    # 프로젝트에 속한 모든 팀원의 역할 가져오기
+    team_members_data = TeamMember.objects.filter(
+        team=project.team,
+        is_active=True
+    ).values('role').distinct()
+    
+    team_role_ids = [member['role'] for member in team_members_data]
+    team_roles = Role.objects.filter(id__in=team_role_ids)
+    
+    for team_role in team_roles:
+        # 해당 역할의 모든 미션 카드
+        cards = GuideCard.objects.filter(
+            role=team_role,
+            is_active=True
+        ).prefetch_related('tasks')
+        
+        # 전체 태스크 수 및 완료된 태스크 수
+        total_tasks = 0
+        completed_tasks = 0
+        
+        for card in cards:
+            for task in card.tasks.all():
+                total_tasks += 1
+                # 이 태스크가 프로젝트에서 완료되었는지 확인
+                is_completed = GuideTaskProgress.objects.filter(
+                    task=task,
+                    project=project,
+                    is_completed=True
+                ).exists()
+                
+                if is_completed:
+                    completed_tasks += 1
+        
+        progress_percent = int((completed_tasks / total_tasks * 100) if total_tasks > 0 else 0)
+        
+        all_role_progress.append({
+            'role': team_role,
+            'total_tasks': total_tasks,
+            'completed_tasks': completed_tasks,
+            'progress_percent': progress_percent,
+        })
     
     context = {
         'project': project,

--- a/apps/projects/forms.py
+++ b/apps/projects/forms.py
@@ -34,12 +34,12 @@ class ProjectDashboardEditForm(forms.ModelForm):
             }),
             "team_rules": forms.Textarea(attrs={
                 "class": "form-control",
-                "placeholder": "팀 규칙을 마크다운 형식으로 작성해주세요\n\n예:\n# 회의 규칙\n- 주 1회 수요일 19시\n- 지각 3회 = 경고\n\n# 코드 리뷰\n- PR 생성 후 2시간 내 리뷰\n- 최소 2명 승인 필수",
+                "placeholder": "팀 규칙을 마크다운으로 작성해주세요\n\n예:\n# 회의\n- 주 1회 수요일 19시\n- 지각 3회 = 경고\n\n# 코드 리뷰\n- PR 2시간 내 리뷰\n- 2명 승인 필수",
                 "rows": 6,
             }),
             "related_links": forms.Textarea(attrs={
                 "class": "form-control",
-                "placeholder": "관련 링크를 줄바꿈으로 구분하여 입력해주세요\n\n예:\nhttps://notion.so/...\nhttps://figma.com/...\nhttps://github.com/...",
+                "placeholder": "관련 링크를 마크다운으로 입력해주세요\n\n예:\n[Notion](https://notion.so/...)\n[Figma](https://figma.com/...)\n[GitHub](https://github.com/...)",
                 "rows": 6,
             }),
         }

--- a/apps/projects/forms.py
+++ b/apps/projects/forms.py
@@ -16,7 +16,6 @@ class ProjectDashboardEditForm(forms.ModelForm):
             "project_image",  # 프로젝트 프로필 사진
             "team_rules",  # 팀 규칙
             "related_links",  # 관련 링크
-            "is_favorite",  # 즐겨찾기
         ]
         widgets = {
             "title": forms.TextInput(attrs={
@@ -40,11 +39,8 @@ class ProjectDashboardEditForm(forms.ModelForm):
             }),
             "related_links": forms.Textarea(attrs={
                 "class": "form-control",
-                "placeholder": "관련 링크를 마크다운 형식으로 작성해주세요\n\n예:\n[Notion](https://notion.so/...)\n[Figma](https://figma.com/...)\n[GitHub](https://github.com/...)",
+                "placeholder": "관련 링크를 줄바꿈으로 구분하여 입력해주세요\n\n예:\nhttps://notion.so/...\nhttps://figma.com/...\nhttps://github.com/...",
                 "rows": 6,
-            }),
-            "is_favorite": forms.CheckboxInput(attrs={
-                "class": "form-check-input",
             }),
         }
 

--- a/apps/projects/templatetags/markdown_tags.py
+++ b/apps/projects/templatetags/markdown_tags.py
@@ -1,0 +1,12 @@
+from django import template
+import markdown as md
+
+register = template.Library()
+
+
+@register.filter
+def markdown(text):
+    """마크다운을 HTML로 변환"""
+    if not text:
+        return ""
+    return md.markdown(text)

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -40,34 +40,50 @@ def _get_project_context(project, user):
         if active_season.project_start <= project.created_at <= active_season.project_end:
             season = active_season
     
-    # 가이드 진척도 계산
+    # 가이드 진척도 계산 (전체 미션 합산)
     guide_progress = None
-    if hasattr(project, 'current_stage') and project.current_stage:
-        try:
-            from apps.guides.models import GuideTask, GuideTaskProgress
+    try:
+        from apps.guides.models import GuideCard, GuideTaskProgress
+        from apps.accounts.models import Role
+        
+        # 프로젝트의 모든 팀원 역할 가져오기
+        team_members_data = team.members.filter(is_active=True).values('role').distinct()
+        team_role_ids = [member['role'] for member in team_members_data]
+        team_roles = Role.objects.filter(id__in=team_role_ids)
+        
+        total_tasks = 0
+        completed_tasks = 0
+        
+        # 각 역할별 모든 미션 카드의 태스크를 합산
+        for team_role in team_roles:
+            cards = GuideCard.objects.filter(
+                role=team_role,
+                is_active=True
+            ).prefetch_related('tasks')
             
-            total_tasks = GuideTask.objects.filter(
-                card__stage=project.current_stage
-            ).count()
-            
-            completed_tasks = GuideTaskProgress.objects.filter(
-                task__card__stage=project.current_stage,
-                project=project,
-                user=user,
-                is_completed=True
-            ).count()
-            
-            progress_percent = int((completed_tasks / total_tasks * 100) if total_tasks > 0 else 0)
-            
-            guide_progress = {
-                'stage': project.current_stage,
-                'total_tasks': total_tasks,
-                'completed_tasks': completed_tasks,
-                'progress_percent': progress_percent,
-            }
-        except:
-            # GuideTask 모델이 없거나 데이터가 없으면 None으로 처리
-            guide_progress = None
+            for card in cards:
+                for task in card.tasks.all():
+                    total_tasks += 1
+                    # 이 태스크가 프로젝트에서 완료되었는지 확인
+                    is_completed = GuideTaskProgress.objects.filter(
+                        task=task,
+                        project=project,
+                        is_completed=True
+                    ).exists()
+                    
+                    if is_completed:
+                        completed_tasks += 1
+        
+        progress_percent = int((completed_tasks / total_tasks * 100) if total_tasks > 0 else 0)
+        
+        guide_progress = {
+            'total_tasks': total_tasks,
+            'completed_tasks': completed_tasks,
+            'progress_percent': progress_percent,
+        }
+    except:
+        # GuideCard 모델이 없거나 데이터가 없으면 None으로 처리
+        guide_progress = None
     
     return {
         "project": project,

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -391,52 +391,71 @@ hr {
     color: #4272EF;
     transition: 0.3s ease;
 }
-
 .d_progress {
     margin-top: 30px;
     text-align: start;
+    margin-bottom: 40px;
 }
 
 .p_title {
     display: flex;
     align-items: center;
     position: relative;
+    margin-bottom: 10px;
 }
 
 .p_title > img {
     width: 50px;
     height: 50px;
+    margin-right: 10px;
 }
 
-.p_title > h3 {
+.p_title > div > h3 {
     font-weight: 600;
     font-size: 22px;
-    margin-top: 2px;
+    margin: 0;
 }
 
-.p_content {
+.role_progress_bar {
+    margin: 10px 0 15px 0;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.role_progress_bar > h3 {
+    width: 40px;
+    font-size: 18px;
+    font-weight: 550;
+    margin: 0;
+}
+
+.progress_bar_container {
     position: relative;
-    margin: 5px 0 100px 47px;
-}
-
-.p_bar {
-    width: 100%;
-    height: 20px;
-    background: #ccc;
+    flex: 1;
+    height: 15px;
+    background: #DDDDDD;
     border-radius: 20px;
-    position: relative;
     overflow: hidden;
 }
 
-.p_real {
+.progress_bar_fill {
     position: absolute;
     top: 0;
     left: 0;
     height: 100%;
     background: #5A88FF;
     border-radius: 20px;
-    transition: width 0.3s ease;
+    transition: width 0.5s ease;
 }
+
+.progress_percent {
+    min-width: 45px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #4272EF;
+}
+
 
 button {
     width: 200px;

--- a/static/css/dashboard_update.css
+++ b/static/css/dashboard_update.css
@@ -419,47 +419,66 @@ hr {
 .d_progress {
     margin-top: 30px;
     text-align: start;
+    margin-bottom: 40px;
 }
 
 .p_title {
     display: flex;
     align-items: center;
     position: relative;
+    margin-bottom: 10px;
 }
 
 .p_title > img {
     width: 50px;
     height: 50px;
+    margin-right: 10px;
 }
 
-.p_title > h3 {
+.p_title > div > h3 {
     font-weight: 600;
     font-size: 22px;
-    margin-top: 2px;
+    margin: 0;
 }
 
-.p_content {
+.role_progress_bar {
+    margin: 10px 0 15px 0;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.role_progress_bar > h3 {
+    width: 40px;
+    font-size: 18px;
+    font-weight: 550;
+    margin: 0;
+}
+
+.progress_bar_container {
     position: relative;
-    margin: 5px 0 100px 47px;
-}
-
-.p_bar {
-    width: 100%;
-    height: 20px;
-    background: #ccc;
+    flex: 1;
+    height: 15px;
+    background: #DDDDDD;
     border-radius: 20px;
-    position: relative;
     overflow: hidden;
 }
 
-.p_real {
+.progress_bar_fill {
     position: absolute;
     top: 0;
     left: 0;
     height: 100%;
     background: #5A88FF;
     border-radius: 20px;
-    transition: width 0.3s ease;
+    transition: width 0.5s ease;
+}
+
+.progress_percent {
+    min-width: 45px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #4272EF;
 }
 
 button {

--- a/templates/projects/dashboard.html
+++ b/templates/projects/dashboard.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %} 
 {% load static %}
+{% load markdown_tags %}
 {% block header %}
 <link rel="stylesheet" href="{% static 'css/dashboard.css' %}" />
 {% endblock %} 
@@ -40,7 +41,7 @@
             <h3>관련 링크</h3>
         </div>
         <div class="l_content">
-            <p>{{ project.related_links|urlize|linebreaksbr }}</p>
+            <p>{{ project.related_links|markdown|safe }}</p>
         </div>
     </div>
     <hr>
@@ -119,7 +120,7 @@
         </div>
         <div class="r_content">
             {% if project.team_rules %}
-                {{ project.team_rules|linebreaks }}
+                {{ project.team_rules|markdown|safe }}
             {% else %}
                 <p>팀 규칙이 없습니다.</p>
             {% endif %}

--- a/templates/projects/dashboard.html
+++ b/templates/projects/dashboard.html
@@ -126,14 +126,20 @@
             {% endif %}
         </div>
     </div>
+    <!-- 진척도 (수정 불가 - 표시만) -->
     <div class="d_progress">
         <div class="p_title">
             <img src="{% static 'images/progress.png' %}" alt="progress">
-            <h3>진척도</h3>
+            <div>
+                <h3>{{ project.title }}의 진척도</h3>
+            </div>
         </div>
-        <div class="p_content">
-            <div class="p_bar"></div>
-            <div class="p_real"></div>
+        <div class="role_progress_bar">
+            <h3>전체</h3>
+            <div class="progress_bar_container">
+                <div class="progress_bar_fill" style="width: {% if guide_progress %}{{ guide_progress.progress_percent }}{% else %}0{% endif %}%;"></div>
+            </div>
+            <span class="progress_percent">{% if guide_progress %}{{ guide_progress.progress_percent }}{% else %}0{% endif %}%</span>
         </div>
     </div>
     {% if is_team_member %}

--- a/templates/projects/dashboard_update.html
+++ b/templates/projects/dashboard_update.html
@@ -130,15 +130,16 @@
         <div class="d_progress">
             <div class="p_title">
                 <img src="{% static 'images/progress.png' %}" alt="progress">
-                <h3>진척도</h3>
+                <div>
+                    <h3>{{ project.title }}의 진척도</h3>
+                </div>
             </div>
-            <div class="p_content">
-                <div class="p_bar"></div>
-                {% if guide_progress %}
-                    <div class="p_real" style="width: {{ guide_progress.progress_percent }}%;"></div>
-                {% else %}
-                    <div class="p_real" style="width: 0%;"></div>
-                {% endif %}
+            <div class="role_progress_bar">
+                <h3>전체</h3>
+                <div class="progress_bar_container">
+                    <div class="progress_bar_fill" style="width: {% if guide_progress %}{{ guide_progress.progress_percent }}{% else %}0{% endif %}%;"></div>
+                </div>
+                <span class="progress_percent">{% if guide_progress %}{{ guide_progress.progress_percent }}{% else %}0{% endif %}%</span>
             </div>
         </div>
         


### PR DESCRIPTION
## 🔥 작업 내용
- 프로젝트 대시보드에서 팀 규칙/관련 링크를 마크다운으로 입력받고 렌더링하도록 적용
  - `markdown_tags` 템플릿 필터 추가
  - dashboard 템플릿에 `|markdown|safe` 적용
- 전체 가이드 진척도(전체 미션 합산) 계산 로직 구현
  - 프로젝트 팀 멤버의 역할 기준으로 GuideCard/Task를 합산하여 진행률 산출
- 대시보드 수정 폼 placeholder 문구 정리

## 🔗 연관 이슈
- resolves #138 

## ⚠️ 참고 사항
- `|markdown|safe` 사용으로 마크다운 내 HTML 허용 위험이 있을 수 있어, 필요 시 safe mode/escape 옵션 검토 필요
- 진척도 계산 쿼리가 역할/태스크 수에 따라 증가할 수 있어 추후 N+1 최적화 여지 있음
