### PR TITLE
Fix: 온보딩 닉네임 중복 확인 오류 수정 및 URL 경로 통일

### DIFF
--- a/apps/accounts/middleware.py
+++ b/apps/accounts/middleware.py
@@ -4,7 +4,6 @@ EXEMPT_PREFIXES = (
     "/admin/",
     "/accounts/",
     "/logout/",
-    "/users/onboarding/",
     "/static/",
     "/media/",
     "/api/",  # Swagger 및 API 테스트용
@@ -17,5 +16,5 @@ class RequireProfileMiddleware:
     def __call__(self, request):
         if request.user.is_authenticated and not request.user.nickname:
             if not request.path.startswith(EXEMPT_PREFIXES):
-                return redirect("/users/onboarding/profile/")
+                return redirect("/accounts/onboarding/profile/")
         return self.get_response(request)

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -37,7 +37,7 @@ class TechStack(models.Model):
         ]
 
     def __str__(self) -> str:
-        return f"{self.name} ({self.get_category_display()})"
+        return self.name
 
 
 class User(AbstractUser):

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -4,6 +4,11 @@ from . import views
 app_name = "accounts"
 
 urlpatterns = [
+    # 검증 API
+    path("check-username/", views.check_username, name="check_username"),
+    path("check-email/", views.check_email, name="check_email"),
+    path("check-nickname/", views.check_nickname, name="check_nickname"),
+    
     # 온보딩
     path("onboarding/profile/", views.onboarding_profile, name="onboarding_profile"),
     

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,7 +19,8 @@ urlpatterns = [
     path("signup/", RedirectView.as_view(url="/accounts/signup/")),
     
     # template views: HTML로 보여줄 주소들
-    path("users/", include("apps.accounts.urls")),
+    path("users/", include("apps.accounts.urls")),  # 기존 경로 (호환성)
+    path("accounts/", include("apps.accounts.urls")),  # 새 경로
     path("projects/", include("apps.projects.urls")),
     path("teams/", include("apps.teams.urls")),
     path("guides/", include("apps.guides.urls")),

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,8 +19,7 @@ urlpatterns = [
     path("signup/", RedirectView.as_view(url="/accounts/signup/")),
     
     # template views: HTML로 보여줄 주소들
-    path("users/", include("apps.accounts.urls")),  # 기존 경로 (호환성)
-    path("accounts/", include("apps.accounts.urls")),  # 새 경로
+    path("accounts/", include("apps.accounts.urls")),
     path("projects/", include("apps.projects.urls")),
     path("teams/", include("apps.teams.urls")),
     path("guides/", include("apps.guides.urls")),

--- a/static/css/mypage.css
+++ b/static/css/mypage.css
@@ -193,13 +193,7 @@
     border: 2px solid;
 }
 
-/* 역할별 색상 */
-.tag-pm {
-    color: #6B8AFF;
-    border-color: #6B8AFF;
-    background-color: transparent;
-}
-
+/* 기술 스택 카테고리별 색상 */
 .tag-frontend {
     color: #FFC107;
     border-color: #FFC107;
@@ -207,7 +201,16 @@
 }
 
 .tag-backend {
+    color: #FF3E88;
+    border-color: #FF3E88;
+    background-color: transparent;
+}
+
+.tag-pm {
     color: #06D6A0;
+    border-color: #06D6A0;
+    background-color: transparent;
+}
     border-color: #06D6A0;
     background-color: transparent;
 }

--- a/static/css/mypage.css
+++ b/static/css/mypage.css
@@ -211,23 +211,19 @@
     border-color: #06D6A0;
     background-color: transparent;
 }
-    border-color: #06D6A0;
-    background-color: transparent;
-}
 
-/* 기술 스택별 색상 */
-.tag-javascript {
-    color: #06D6A0;
-    border-color: #06D6A0;
-    background-color: transparent;
-}
-
-.tag-react-native,
-.tag-react,
-.tag-reactnative {
+/* 역할별 색상 */
+.tag-frontend {
     color: #FFC107;
     border-color: #FFC107;
     background-color: transparent;
+}
+
+.tag-backend {
+    color: #FF3E88;
+    border-color: #FF3E88;
+    background-color: transparent;
+}
 }
 
 .tag-html {

--- a/static/css/onboarding_profile.css
+++ b/static/css/onboarding_profile.css
@@ -153,7 +153,7 @@ form > div:nth-child(2) {
 /* Nickname input styling */
 form > div:nth-child(2) input[type="text"] {
   width: 100%;
-  padding: 12px 80px 12px 16px;
+  padding: 12px 16px;
   border: 1px solid var(--border-color);
   border-radius: 10px;
   font-size: 15px;
@@ -168,29 +168,6 @@ form > div:nth-child(2) input[type="text"]:focus {
   border-color: var(--primary-blue);
   background-color: var(--white);
   box-shadow: 0 0 0 3px rgba(65, 105, 225, 0.1);
-}
-
-/* Create "확인" button using ::after on the second div */
-form > div:nth-child(2)::after {
-  content: '확인';
-  position: absolute;
-  right: 4px;
-  top: 50%;
-  transform: translateY(-50%);
-  margin-top: 14px;
-  background-color: var(--primary-blue);
-  color: var(--white);
-  padding: 10px 20px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s;
-  pointer-events: auto;
-}
-
-form > div:nth-child(2)::after:hover {
-  background-color: var(--primary-hover);
 }
 
 /* Labels */

--- a/static/css/profile_edit.css
+++ b/static/css/profile_edit.css
@@ -272,19 +272,20 @@ body {
     transition: all 0.3s ease;
 }
 
-.tag-item:nth-child(3n+1) {
-    color: #06b6d4;
-    border-color: #06b6d4;
+/* 기술 스택 카테고리별 색상 */
+.tag-frontend {
+    color: #FFC107;
+    border-color: #FFC107;
 }
 
-.tag-item:nth-child(3n+2) {
-    color: #f59e0b;
-    border-color: #f59e0b;
+.tag-backend {
+    color: #FF3E88;
+    border-color: #FF3E88;
 }
 
-.tag-item:nth-child(3n+3) {
-    color: #10b981;
-    border-color: #10b981;
+.tag-pm {
+    color: #06D6A0;
+    border-color: #06D6A0;
 }
 
 .empty-msg {

--- a/templates/account/mypage.html
+++ b/templates/account/mypage.html
@@ -53,7 +53,7 @@
                 <h3 class="side-title">기술 스택</h3>
                 <div class="tags">
                     {% for tech in user_obj.tech_stacks.all %}
-                        <span class="tag-item"># {{ tech.name }}</span>
+                        <span class="tag-item tag-{{ tech.category|lower }}">{{ tech.name }}</span>
                     {% empty %}
                         <p class="empty-msg">등록된 스택이 없습니다.</p>
                     {% endfor %}

--- a/templates/account/mypage.html
+++ b/templates/account/mypage.html
@@ -53,7 +53,7 @@
                 <h3 class="side-title">기술 스택</h3>
                 <div class="tags">
                     {% for tech in user_obj.tech_stacks.all %}
-                        <span class="tag-item tag-{{ tech.category|lower }}">{{ tech.name }}</span>
+                        <span class="tag-item tag-{{ tech.category|lower }}"># {{ tech.name }}</span>
                     {% empty %}
                         <p class="empty-msg">등록된 스택이 없습니다.</p>
                     {% endfor %}

--- a/templates/account/onboarding_profile.html
+++ b/templates/account/onboarding_profile.html
@@ -9,7 +9,14 @@
 
   <div>
     {{ form.nickname.errors }}
-    {{ form.nickname.label_tag }} {{ form.nickname }}
+    {{ form.nickname.label_tag }} 
+    <div style="display: flex; gap: 10px; align-items: center;">
+      {{ form.nickname }}
+      <button type="button" id="nicknameCheckBtn" style="padding: 10px 20px; background: #4272EF; color: white; border: none; border-radius: 8px; cursor: pointer; font-size: 14px; font-weight: 600; white-space: nowrap; flex-shrink: 0;">
+        중복 확인
+      </button>
+    </div>
+    <div id="nicknameCheckResult" style="margin-top: 8px; font-size: 14px; display: none;"></div>
   </div>
 
   <div>
@@ -36,6 +43,55 @@
   </button>
 </form>
   <script>
+  // 닉네임 중복 확인
+  (function() {
+    const nicknameInput = document.querySelector('input[name="nickname"]');
+    const checkBtn = document.getElementById('nicknameCheckBtn');
+    const resultDiv = document.getElementById('nicknameCheckResult');
+
+    if (!nicknameInput || !checkBtn || !resultDiv) return;
+
+    checkBtn.addEventListener('click', async (e) => {
+      e.preventDefault();
+      
+      const nickname = nicknameInput.value.trim();
+      
+      if (!nickname) {
+        resultDiv.textContent = '닉네임을 입력해주세요.';
+        resultDiv.style.color = '#FF6B6B';
+        resultDiv.style.display = 'block';
+        return;
+      }
+
+      try {
+        const response = await fetch(`/accounts/check-nickname/?nickname=${encodeURIComponent(nickname)}`);
+        const data = await response.json();
+
+        resultDiv.style.display = 'block';
+        
+        if (data.available) {
+          resultDiv.textContent = '✓ 사용 가능한 닉네임입니다.';
+          resultDiv.style.color = '#51CF66';
+          nicknameInput.style.borderColor = '#51CF66';
+        } else {
+          resultDiv.textContent = data.message || '이미 사용 중인 닉네임입니다.';
+          resultDiv.style.color = '#FF6B6B';
+          nicknameInput.style.borderColor = '#FF6B6B';
+        }
+      } catch (error) {
+        resultDiv.textContent = '닉네임 확인 중 오류가 발생했습니다.';
+        resultDiv.style.color = '#FF6B6B';
+        resultDiv.style.display = 'block';
+      }
+    });
+
+    // 입력 필드 변경 시 결과 숨기기
+    nicknameInput.addEventListener('input', () => {
+      resultDiv.style.display = 'none';
+      nicknameInput.style.borderColor = '';
+    });
+  })();
+
   // 온보딩: 프로필 이미지 영역 클릭으로 파일 선택 및 미리보기
   (function() {
     // robustly find the file input for profile_image inside the form

--- a/templates/account/profile_edit.html
+++ b/templates/account/profile_edit.html
@@ -78,9 +78,9 @@
                 <h3 class="side-title">기술 스택</h3>
                 <div class="tags">
                     {% for tech in user.tech_stacks.all %}
-                    <div class="tag-item">
+                    <span class="tag-item tag-{{ tech.category|lower }}">
                         # {{ tech.name }}
-                    </div>
+                    </span>
                     {% empty %}
                     <p class="empty-msg">등록된 기술 스택이 없습니다.</p>
                     {% endfor %}


### PR DESCRIPTION
## 🔥 작업 내용
- accounts 라우팅 경로를 `/accounts/`로 통일 (기존 `/users/` 제거)
- 온보딩 프로필 페이지 닉네임 중복 확인 UI 수정
  - CSS pseudo 버튼(::after) 제거 → 실제 버튼 추가
  - `/accounts/check-nickname/` API 호출로 통일 및 결과 메시지 표시
- 마이페이지 기술 스택 태그 클래스/색상 적용 및 CSS 정리

## 🔗 연관 이슈
- resolves #143 