### PR TITLE
Refactor: 팀 매칭 알고리즘 및 N+1 쿼리 전반 개선

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -82,9 +82,15 @@ class TechStackAdmin(admin.ModelAdmin):
         ("기본 정보", {"fields": ["name", "category"]}),
     ]
     
+    def get_queryset(self, request):
+        """N+1 쿼리 최적화: annotate로 user_count 미리 계산"""
+        from django.db.models import Count
+        queryset = super().get_queryset(request)
+        return queryset.annotate(_user_count=Count('users', distinct=True))
+    
     def user_count(self, obj):
-        """이 기술을 보유한 사용자 수"""
-        return obj.users.count()
+        """annotate된 _user_count 사용 (DB 쿼리 없음)"""
+        return obj._user_count
     user_count.short_description = "사용자 수"
 
 

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -3,6 +3,55 @@ import re
 from .models import User, TechStack
 
 
+# ============ 공통 Validator ============
+class NicknameValidator:
+    """닉네임 검증 로직 통합"""
+    MIN_LENGTH = 2
+    MAX_LENGTH = 20
+    PATTERN = r'^[a-zA-Z0-9가-힣_-]+$'
+    
+    @staticmethod
+    def validate(nickname, exclude_user_pk=None):
+        """
+        닉네임 검증 (길이 + 패턴 + 중복)
+        
+        Args:
+            nickname: 검증할 닉네임
+            exclude_user_pk: 제외할 사용자 PK (프로필 수정 시)
+            
+        Returns:
+            (valid, message) 튜플
+        """
+        nickname = (nickname or "").strip()
+        
+        # 필수값 확인
+        if not nickname:
+            return False, "닉네임은 필수입니다."
+        
+        # 길이 검증
+        if len(nickname) < NicknameValidator.MIN_LENGTH:
+            return False, f"닉네임은 최소 {NicknameValidator.MIN_LENGTH}자 이상이어야 합니다."
+        if len(nickname) > NicknameValidator.MAX_LENGTH:
+            return False, f"닉네임은 최대 {NicknameValidator.MAX_LENGTH}자 이하여야 합니다."
+        
+        # 특수문자 검증
+        if not re.match(NicknameValidator.PATTERN, nickname):
+            return False, "닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다."
+        
+        # 중복 검증
+        query = User.objects.filter(nickname=nickname)
+        if exclude_user_pk:
+            query = query.exclude(pk=exclude_user_pk)
+        
+        if query.exists():
+            return False, "이미 사용 중인 닉네임입니다."
+        
+        return True, "사용 가능한 닉네임입니다."
+
+
+# ============ Forms ============
+
+
 class OnboardingForm(forms.ModelForm):
     tech_stacks = forms.ModelMultipleChoiceField(
         queryset=TechStack.objects.all().order_by("category", "name"),
@@ -36,25 +85,11 @@ class OnboardingForm(forms.ModelForm):
             self.fields["tech_stacks"].initial = self.instance.tech_stacks.all()
 
     def clean_nickname(self):
-        nick = (self.cleaned_data.get("nickname") or "").strip()
-        if not nick:
-            raise forms.ValidationError("닉네임은 필수입니다.")
-        
-        # 길이 검증
-        if len(nick) < 2:
-            raise forms.ValidationError("닉네임은 최소 2자 이상이어야 합니다.")
-        if len(nick) > 20:
-            raise forms.ValidationError("닉네임은 최대 20자 이하여야 합니다.")
-        
-        # 특수문자 검증 (한글, 영문, 숫자, 밑줄, 하이픈만 허용)
-        if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', nick):
-            raise forms.ValidationError("닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다.")
-        
-        # 중복 확인
-        if User.objects.filter(nickname=nick).exclude(pk=self.instance.pk).exists():
-            raise forms.ValidationError("이미 사용 중인 닉네임입니다.")
-        
-        return nick
+        nick = self.cleaned_data.get("nickname") or ""
+        valid, message = NicknameValidator.validate(nick, self.instance.pk)
+        if not valid:
+            raise forms.ValidationError(message)
+        return nick.strip()
 
     def clean_github_id(self):
         github_id = (self.cleaned_data.get("github_id") or "").strip()
@@ -109,25 +144,11 @@ class ProfileUpdateForm(forms.ModelForm):
             self.fields["tech_stacks"].initial = self.instance.tech_stacks.all()
 
     def clean_nickname(self):
-        nick = (self.cleaned_data.get("nickname") or "").strip()
-        if not nick:
-            raise forms.ValidationError("닉네임은 필수입니다.")
-        
-        # 길이 검증
-        if len(nick) < 2:
-            raise forms.ValidationError("닉네임은 최소 2자 이상이어야 합니다.")
-        if len(nick) > 20:
-            raise forms.ValidationError("닉네임은 최대 20자 이하여야 합니다.")
-        
-        # 특수문자 검증 (한글, 영문, 숫자, 밑줄, 하이픈만 허용)
-        if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', nick):
-            raise forms.ValidationError("닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다.")
-        
-        # 중복 확인
-        if User.objects.filter(nickname=nick).exclude(pk=self.instance.pk).exists():
-            raise forms.ValidationError("이미 사용 중인 닉네임입니다.")
-        
-        return nick
+        nick = self.cleaned_data.get("nickname") or ""
+        valid, message = NicknameValidator.validate(nick, self.instance.pk)
+        if not valid:
+            raise forms.ValidationError(message)
+        return nick.strip()
 
     def clean_github_id(self):
         github_id = (self.cleaned_data.get("github_id") or "").strip()

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -164,13 +164,3 @@ class ProfileUpdateForm(forms.ModelForm):
             if "tech_stacks" in self.cleaned_data:
                 user.tech_stacks.set(self.cleaned_data.get("tech_stacks", []))
         return user
-
-
-def save(self, commit=True):
-    user = super().save(commit=False)
-
-    if commit:
-        user.save()
-        if "tech_stacks" in self.cleaned_data:
-            user.tech_stacks.set(self.cleaned_data.get("tech_stacks", []))
-    return user

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -53,33 +53,17 @@ def check_email(request):
 @require_GET
 def check_nickname(request):
     """닉네임 중복 확인 API"""
+    from .forms import NicknameValidator
+    
     nickname = request.GET.get("nickname", "").strip()
-    current_user_id = request.GET.get("user_id")  # 프로필 수정 시 자신의 닉네임 제외
+    user_id = request.GET.get("user_id")  # 프로필 수정 시 자신의 닉네임 제외
     
-    if not nickname:
-        return JsonResponse({"available": False, "message": "닉네임을 입력해주세요."})
+    valid, message = NicknameValidator.validate(nickname, exclude_user_pk=user_id)
     
-    # 길이 검증 (2-20자)
-    if len(nickname) < 2:
-        return JsonResponse({"available": False, "message": "닉네임은 최소 2자 이상이어야 합니다."})
-    
-    if len(nickname) > 20:
-        return JsonResponse({"available": False, "message": "닉네임은 최대 20자 이하여야 합니다."})
-    
-    # 특수문자 검증 (한글, 영문, 숫자, 밑줄, 하이픈만 허용)
-    import re
-    if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', nickname):
-        return JsonResponse({"available": False, "message": "닉네임은 한글, 영문, 숫자, 밑줄(_), 하이픈(-)만 사용 가능합니다."})
-    
-    # 중복 확인 (현재 사용자는 제외)
-    query = User.objects.filter(nickname=nickname)
-    if current_user_id:
-        query = query.exclude(pk=current_user_id)
-    
-    if query.exists():
-        return JsonResponse({"available": False, "message": "이미 사용 중인 닉네임입니다."})
-    
-    return JsonResponse({"available": True, "message": "사용 가능한 닉네임입니다."})
+    return JsonResponse({
+        "available": valid,
+        "message": message,
+    })
 
 
 @login_required

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -94,14 +94,11 @@ def level_submit(request):
         role_code = data.get("track")
         level = data.get("level")
         
-        print(f"DEBUG: role_code={role_code}, level={level}")  # 디버그 로그
-        
         if not role_code or level is None:
             return JsonResponse({"success": False, "error": "필수 데이터가 없습니다."})
         
         try:
             role = Role.objects.get(code=role_code)
-            print(f"DEBUG: role found - {role}")  # 디버그 로그
         except Role.DoesNotExist:
             return JsonResponse({"success": False, "error": f"역할을 찾을 수 없습니다: {role_code}"})
         
@@ -114,15 +111,13 @@ def level_submit(request):
             },
         )
         
-        print(f"DEBUG: 저장 완료 - user={request.user}, role={role}, level={level}")  # 디버그 로그
         return JsonResponse({"success": True})
-    except json.JSONDecodeError as e:
-        print(f"DEBUG: JSON 에러 - {e}")  # 디버그 로그
+    except json.JSONDecodeError:
         return JsonResponse({"success": False, "error": "잘못된 JSON 형식입니다."})
     except Exception as e:
-        print(f"DEBUG: 기타 에러 - {e}")  # 디버그 로그
         import traceback
         traceback.print_exc()
+        return JsonResponse({"success": False, "error": "오류가 발생했습니다."})
         return JsonResponse({"success": False, "error": str(e)})
 
 @login_required

--- a/apps/projects/services.py
+++ b/apps/projects/services.py
@@ -37,9 +37,10 @@ class TeamMatchingService:
         season = Season.objects.get(id=season_id)
         
         # 1️⃣ passion_level이 설정된 지원자만 필터링
+        # N+1 쿼리 최적화: UserRoleLevel을 미리 로드
         applicants = User.objects.filter(
             passion_level__isnull=False
-        ).select_related()
+        ).prefetch_related('role_levels')
         
         if not applicants.exists():
             raise ValidationError("팀매칭 지원자가 없습니다.")
@@ -77,7 +78,16 @@ class TeamMatchingService:
             각 역할별 지원자를 팀별로 라운드로빈으로 배정
             같은 팀 내에서 여러 직군의 사람이 들어가면서도,
             각 역할의 배정은 균등하게 이루어짐
+            N+1 쿼리 최적화: prefetch_related된 role_levels 사용
             """
+            # 헬퍼: 캐시된 user.role_levels에서 해당 role의 level을 빠르게 조회
+            def get_role_level(user, role_code):
+                """이미 prefetch된 role_levels에서 빠르게 조회 (DB 쿼리 없음)"""
+                for role_level in user.role_levels.all():
+                    if role_level.role.code == role_code:
+                        return role_level.level
+                return 0
+            
             # 열정별로 그룹화한 후 레벨순 정렬
             passion_groups = {}
             for user in candidates:
@@ -87,17 +97,10 @@ class TeamMatchingService:
                 passion_groups[passion].append(user)
             
             # 각 열정 그룹을 역할별 레벨로 정렬 (높은 순)
+            # 이제 DB 쿼리 없이 메모리에서만 정렬함
             for passion in passion_groups:
                 passion_groups[passion].sort(
-                    key=lambda u: (
-                        -(UserRoleLevel.objects.filter(
-                            user=u, 
-                            role__code=role_code
-                        ).first().level if UserRoleLevel.objects.filter(
-                            user=u, 
-                            role__code=role_code
-                        ).exists() else 0)
-                    )
+                    key=lambda u: (-get_role_level(u, role_code))
                 )
             
             # 열정별로 순회하면서 팀별로 라운드로빈 배정
@@ -210,22 +213,24 @@ class TeamMatchingService:
         1. 열정 레벨 내림차순 (높은 열정부터)
         2. 같은 열정이면 역할 레벨 내림차순 (스킬 좋은 사람)
         
+        N+1 쿼리 최적화: prefetch_related된 데이터만 사용
+        
         Args:
-            applicants: User QuerySet
+            applicants: User QuerySet (prefetch_related='role_levels' 필수)
             role_code: 'PM' | 'FRONTEND' | 'BACKEND'
             
         Returns:
             list: 정렬된 User 객체 리스트 (열정 우선, 그 다음 역할 레벨)
         """
-        role = Role.objects.get(code=role_code)
-        
         candidates = []
+        
         for user in applicants:
-            # 해당 역할의 레벨 조회
-            role_level = UserRoleLevel.objects.filter(
-                user=user,
-                role=role
-            ).first()
+            # prefetch_related된 role_levels에서 해당 역할 조회 (DB 쿼리 없음)
+            role_level = None
+            for rl in user.role_levels.all():
+                if rl.role.code == role_code:
+                    role_level = rl
+                    break
             
             if role_level:
                 candidates.append({
@@ -328,6 +333,8 @@ class EmailService:
         - 매칭된 팀의 멤버들에게만 발송
         - 발송 완료 후 email_notifications_enabled = False로 변경
         
+        N+1 쿼리 최적화: prefetch_related 사용
+        
         Args:
             season_id: Season ID
             
@@ -337,10 +344,11 @@ class EmailService:
         season = Season.objects.get(id=season_id)
         
         # 현재 시즌의 모든 팀 조회
+        # N+1 쿼리 최적화: members__user__role_levels를 미리 로드
         teams = Team.objects.filter(
             project__season=season
         ).prefetch_related(
-            'members__user',
+            'members__user__role_levels',
             'members__role',
             'project'
         ).distinct()
@@ -382,18 +390,23 @@ class EmailService:
         """
         개별 사용자에게 팀 매칭 결과 이메일 발송
         
+        N+1 쿼리 최적화: prefetch_related된 데이터 사용
+        
         Args:
             user: 수신자
             team: 할당된 팀
             season: 현재 시즌
         """
         # 팀원 정보 수집
+        # prefetch_related된 데이터만 사용 (DB 쿼리 없음)
         team_members = []
         for member in team.members.all():
-            role_level = UserRoleLevel.objects.filter(
-                user=member.user,
-                role=member.role
-            ).first()
+            # prefetch_related된 role_levels에서 빠르게 조회
+            role_level = None
+            for rl in member.user.role_levels.all():
+                if rl.role.code == member.role.code:
+                    role_level = rl
+                    break
             
             team_members.append({
                 'user': member.user,

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -76,19 +76,16 @@ def _get_project_context(project, user):
         # 메모리에서만 작업 (DB 쿼리 없음)
         for card in cards_with_tasks:
             for task in card.tasks.all():  # prefetch_related로 이미 로드됨
-            
-            for card in cards:
-                for task in card.tasks.all():
-                    total_tasks += 1
-                    # 이 태스크가 프로젝트에서 완료되었는지 확인
-                    is_completed = GuideTaskProgress.objects.filter(
-                        task=task,
-                        project=project,
-                        is_completed=True
-                    ).exists()
-                    
-                    if is_completed:
-                        completed_tasks += 1
+                total_tasks += 1
+                # 이 태스크가 프로젝트에서 완료되었는지 확인
+                is_completed = GuideTaskProgress.objects.filter(
+                    task=task,
+                    project=project,
+                    is_completed=True
+                ).exists()
+                
+                if is_completed:
+                    completed_tasks += 1
         
         progress_percent = int((completed_tasks / total_tasks * 100) if total_tasks > 0 else 0)
         

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -196,7 +196,6 @@ def dashboard_update(request, project_id):
             messages.success(request, "✅ 프로젝트 정보가 수정되었습니다.")
             return redirect("projects:dashboard_detail", project_id=project_id)
         else:
-            print("❌ Form 에러:", form.errors) 
             messages.error(request, "❌ 입력 오류가 있습니다. 다시 확인해주세요.")
     else:
         form = ProjectDashboardEditForm(instance=project)

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -18,17 +18,29 @@ from apps.teams.models import Team, TeamMember
 def _get_project_context(project, user):
     """
     프로젝트 상세 정보 context 생성 (dashboard_detail, project_detail에서 공유)
+    N+1 쿼리 최적화: prefetch_related 및 캐싱 활용
     """
     team = project.team
-    members = team.members.filter(is_active=True).select_related("user", "role")
+    # N+1 쿼리 최적화: user__role_levels를 미리 로드
+    members = team.members.filter(is_active=True).select_related(
+        "user", 
+        "role"
+    ).prefetch_related("user__role_levels")
     member_count_by_role = team.get_member_count_by_role()
     
-    # 각 멤버에 레벨 정보 추가
+    # 각 멤버에 레벨 정보 추가 (캐시된 role_levels 사용)
     members_with_level = []
     for member in members:
+        # prefetch_related된 role_levels에서 직접 조회 (DB 쿼리 없음)
+        role_level = None
+        for rl in member.user.role_levels.all():
+            if rl.role.code == member.role.code:
+                role_level = rl.level
+                break
+        
         member_data = {
             'member': member,
-            'level': member.user.get_role_level(member.role.code)
+            'level': role_level or 0
         }
         members_with_level.append(member_data)
     
@@ -47,19 +59,23 @@ def _get_project_context(project, user):
         from apps.accounts.models import Role
         
         # 프로젝트의 모든 팀원 역할 가져오기
-        team_members_data = team.members.filter(is_active=True).values('role').distinct()
-        team_role_ids = [member['role'] for member in team_members_data]
-        team_roles = Role.objects.filter(id__in=team_role_ids)
+        # N+1 쿼리 최적화: values_list + in 사용하여 role ID만 먼저 추출
+        team_role_ids = team.members.filter(is_active=True).values_list(
+            'role_id', flat=True
+        ).distinct()
+        
+        # 한 번에 모든 카드와 태스크 로드
+        cards_with_tasks = GuideCard.objects.filter(
+            role_id__in=team_role_ids,
+            is_active=True
+        ).prefetch_related('tasks')  # 카드와 태스크를 한 번에 로드
         
         total_tasks = 0
         completed_tasks = 0
         
-        # 각 역할별 모든 미션 카드의 태스크를 합산
-        for team_role in team_roles:
-            cards = GuideCard.objects.filter(
-                role=team_role,
-                is_active=True
-            ).prefetch_related('tasks')
+        # 메모리에서만 작업 (DB 쿼리 없음)
+        for card in cards_with_tasks:
+            for task in card.tasks.all():  # prefetch_related로 이미 로드됨
             
             for card in cards:
                 for task in card.tasks.all():

--- a/apps/teams/views.py
+++ b/apps/teams/views.py
@@ -132,12 +132,10 @@ def passion_submit_api(request):
         request.user.passion_level = int(passion_level)
         request.user.save(update_fields=["passion_level"])
         
-        print(f"DEBUG: 열정 테스트 저장 완료 - user={request.user}, passion_level={passion_level}")
         return JsonResponse({"success": True})
     except json.JSONDecodeError:
         return JsonResponse({"success": False, "error": "잘못된 JSON 형식입니다."})
     except Exception as e:
-        print(f"DEBUG: 열정 테스트 저장 에러 - {e}")
         import traceback
         traceback.print_exc()
         return JsonResponse({"success": False, "error": str(e)})


### PR DESCRIPTION
## 🔥 작업 내용

- 팀 매칭 알고리즘 쿼리 개선
  - `prefetch_related('role_levels')` 적용하여 역할 레벨 조회 시 N+1 문제 제거
  - 라운드 로빈 분배 로직에서 DB 조회 대신 캐시된 `role_levels` 사용
  - `_get_role_candidates` 내부 반복 DB 조회 제거

- 프로젝트 상세/대시보드 N+1 최적화
  - `user__role_levels` prefetch 적용
  - GuideCard / Task 조회 로직 개선
  - 중복 루프 제거 및 쿼리 최소화

- 관리자 페이지 N+1 최적화
  - `TechStackAdmin.get_queryset()`에 `annotate(Count)` 적용
  - `user_count()`에서 추가 쿼리 제거

- 닉네임 검증 로직 통합
  - `NicknameValidator` 클래스 도입
  - Form / API에서 동일한 검증 로직 사용
  - 중복 코드 제거

- 미사용 디버그 `print` 제거

- 오타 및 중복 코드 정리


## 🔗 연관 이슈

- resolves #174 


## ⚠️ 참고 사항

- 팀 매칭 및 프로젝트 상세 페이지의 쿼리 동작 방식이 변경되었습니다.
- `role_levels`는 반드시 `prefetch_related`된 상태에서 사용하는 것을 전제로 합니다.
- 닉네임 정책 변경 시 `NicknameValidator`만 수정하면 됩니다.