### PR TITLE
fix: team/status에서 이미지 비율 문제 해결

### DIFF
--- a/static/css/team.css
+++ b/static/css/team.css
@@ -41,6 +41,8 @@ body {
 .t_member > .profile_section > .profile_img {
     width: 110px; height: 110px;
     border-radius: 50%;
+    object-fit: cover;
+    object-position: center;
 }
 
 .t_member >.profile_section> .level_img {


### PR DESCRIPTION
## 🔥 작업 내용
<!-- 이 PR에서 무엇을 했는지 요약 -->
team/status 부분에도 object-fit 추가 -> 이미지 가운대로 자르기 

## 🔗 연관 이슈
<!-- closes / resolves / fixes 중 하나 사용 -->
- resolves #186 

